### PR TITLE
[BUGFIX] Fix OptionError in pandas 

### DIFF
--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -1,3 +1,6 @@
+v0.0.13:
+   * Bugfix: update dependency version of `longling`
+
 v0.0.12:
    * limit the range of parameters in IRT and MIRT
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ test_deps = [
 
 setup(
     name='EduCDM',
-    version='0.0.12',
+    version='0.0.13',
     extras_require={
         'test': test_deps,
     },
@@ -19,7 +19,7 @@ setup(
         "numpy>=1.16.5",
         "scikit-learn",
         "pandas",
-        "longling>=1.3.23"
+        "longling>=1.3.33"
     ],  # And any other dependencies for needs
     entry_points={
     },


### PR DESCRIPTION
Thanks for sending a pull request! 
Please make sure you click the link above to view the [contribution guidelines](../blob/master/CONTRIBUTE.md), 
then fill out the blanks below.

## Description ##
(Brief description on what this PR is about)

### What does this implement/fix? Explain your changes.
Fix the raised `OptionError` when testing `EduCDM` with `pandas 1.4`

#### Pull request type
- [ ] [DATASET] Add a new dataset
- [x] [BUGFIX] Bugfix
- [ ] [FEATURE] New feature (non-breaking change which adds functionality)
- [ ] [BREAKING] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] [STYLE] Code style update (formatting, renaming)
- [ ] [REFACTOR] Refactoring (no functional changes, no api changes)
- [ ] [BUILD] Build related changes
- [ ] [DOC] Documentation content changes
- [ ] [Sync] Synchronization with a repository 
- [ ] [OTHER] Other (please describe): 


#### Changes
- upgrade the version of `longling` into 1.3.33

### Does this close any currently open issues?
N/A

### Any relevant logs, error output, etc?
```
tests/irr/test_dina.py:9: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
EduCDM/IRR/DINA.py:82: in train
    print("[Epoch %d]\n%s" % (e, eval_data))
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/longling/ML/metrics/utils.py:24: in __repr__
    return result_format(self)
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/longling/ML/toolkit/formatter/EvalFMT.py:227: in result_format
    _ret.append(table_format(table))
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/longling/lib/formatter.py:106: in pandas_format
    with pandas_session():
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/contextlib.py:113: in __enter__
    return next(self.gen)
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/longling/lib/formatter.py:89: in pandas_session
    pd.pandas.set_option(key, value)
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pandas/_config/config.py:256: in __call__
    return self.__func__(*args, **kwds)
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pandas/_config/config.py:149: in _set_option
    key = _get_single_key(k, silent)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

pat = 'max_rows', silent = False

    def _get_single_key(pat: str, silent: bool) -> str:
        keys = _select_options(pat)
        if len(keys) == 0:
            if not silent:
                _warn_if_deprecated(pat)
            raise OptionError(f"No such keys(s): {repr(pat)}")
        if len(keys) > 1:
>           raise OptionError("Pattern matched multiple keys")
E           pandas._config.config.OptionError: 'Pattern matched multiple keys'

/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pandas/_config/config.py:116: OptionError
```

## Checklist ##
Before you submit a pull request, please make sure you have to following:

### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [FEATURE], [BREAKING], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage and al tests passing
- [x] Code is well-documented (extended the README / documentation, if necessary)
- [x] If this PR is your first one, add your name and github account to [AUTHORS.md](../blob/master/AUTHORS.md)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
